### PR TITLE
Twitter関連の更新をいい感じに行う

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -12,5 +12,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 
+require 'whenever/capistrano'
+
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'therubyracer', '~> 0.12.2', platforms: :ruby
 gem 'twitter', '~> 5.13.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn', '~> 4.8.3'
+gem 'whenever', :require => false
 
 group :development do
   gem 'silencer', '~> 0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     coderay (1.1.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -274,6 +275,8 @@ GEM
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
       rack-test (>= 0.5.3)
+    whenever (0.9.7)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -319,6 +322,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (~> 4.8.3)
   webrat (~> 0.7.3)
+  whenever
 
 BUNDLED WITH
    1.12.0.rc

--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -6,4 +6,8 @@ class Achievement < ActiveRecord::Base
   validates :date, presence: true
   validates :text, presence: true
   validates :user_id, presence: true
+
+  def self.latest_twitter_status_id
+    self.where.not(:twitter_status_id => nil).order(:twitter_status_id => 'desc').first.twitter_status_id
+  end
 end

--- a/app/models/achievement.rb
+++ b/app/models/achievement.rb
@@ -8,6 +8,6 @@ class Achievement < ActiveRecord::Base
   validates :user_id, presence: true
 
   def self.latest_twitter_status_id
-    self.where.not(:twitter_status_id => nil).order(:twitter_status_id => 'desc').first.twitter_status_id
+    Achievement.maximum(:twitter_status_id)
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,30 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Fetch profile image
+every 1.day, :at => '4:30 am' do
+  rake 'users:fetch_profile_image'
+end
+
+# Fetch achievements
+every 3.minutes do
+  rake 'achievements:fetch'
+end

--- a/db/migrate/20161008093702_add_twitter_status_id_to_achievement.rb
+++ b/db/migrate/20161008093702_add_twitter_status_id_to_achievement.rb
@@ -1,0 +1,5 @@
+class AddTwitterStatusIdToAchievement < ActiveRecord::Migration
+  def change
+    add_column :achievements, :twitter_status_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141210145027) do
+ActiveRecord::Schema.define(version: 20161008093702) do
 
   create_table "achievements", force: :cascade do |t|
     t.date     "date"
-    t.text     "text",       limit: 65535
-    t.integer  "user_id",    limit: 4
+    t.text     "text",              limit: 65535
+    t.integer  "user_id",           limit: 4
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "twitter_status_id", limit: 255
   end
 
   add_index "achievements", ["user_id"], name: "index_achievements_on_user_id", using: :btree
@@ -153,7 +154,7 @@ ActiveRecord::Schema.define(version: 20141210145027) do
   add_index "menus", ["section"], name: "index_menus_on_section", using: :btree
 
   create_table "twitter_accounts", force: :cascade do |t|
-    t.decimal  "uid",                     precision: 10
+    t.string   "uid",         limit: 255
     t.string   "screen_name", limit: 255
     t.integer  "user_id",     limit: 4
     t.datetime "created_at"

--- a/lib/tasks/achievements.rake
+++ b/lib/tasks/achievements.rake
@@ -1,0 +1,29 @@
+namespace :achievements do
+  desc 'Fetch achievements from Twitter'
+  task :fetch => :environment do
+    client = Twitter::REST::Client.new do |config|
+      config.bearer_token = ENV['BEARER_TOKEN']
+    end
+
+    since_id = Achievement.latest_twitter_status_id
+    search_results = client.search('#BEATECH_成果報告', :count => 50, :since_id => since_id)
+
+    search_results.each do |result|
+      twitter_user = TwitterAccount.find_by_uid(result.user.id)
+      next if twitter_user.nil?
+      next if result.retweet?
+
+      achievement = Achievement.new
+      achievement.user_id = twitter_user.user_id
+      achievement.text = result.text.gsub(/\s?\#BEATECH_成果報告/, '')
+      achievement.date = result.created_at.to_date
+      achievement.twitter_status_id = result.id
+      achievement.save
+
+      puts "add achievement: #{result.user.screen_name} (#{result.id}) [#{result.created_at}]: #{result.text}"
+    end
+
+    puts "Achievement entries added."
+    Entry.find_by_url('achievements').touch
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,28 @@
+namespace :users do
+  desc 'Fetch profile image from Twitter account'
+  task :fetch_profile_image => :environment do
+    client = Twitter::REST::Client.new do |config|
+      config.bearer_token = ENV['BEARER_TOKEN']
+    end
+
+    ActiveRecord::Base.record_timestamps = false
+    User.all.each do |user|
+      twitter_account = user.twitter_accounts.first
+      if twitter_account.present?
+        print "#{user.name}: "
+        begin
+          profile_image_url = client.user(twitter_account.uid.to_i, :skip_status => true).profile_image_url
+          user.profile_image = profile_image_url.to_s if profile_image_url.present?
+          user.save
+          puts 'success'
+        rescue => e
+          puts 'error'
+          puts e
+        end
+        sleep(1)
+      end
+    end
+
+    ActiveRecord::Base.record_timestamps = true
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -5,8 +5,10 @@ namespace :users do
       config.bearer_token = ENV['BEARER_TOKEN']
     end
 
+    # Update profile images silently
     ActiveRecord::Base.record_timestamps = false
-    User.all.each do |user|
+
+    User.find_each do |user|
       twitter_account = user.twitter_accounts.first
       if twitter_account.present?
         print "#{user.name}: "


### PR DESCRIPTION
closes #46.

Capistranoとの連携の方は試してないのでうまく動かないかもしれません。
Capistranoをそもそも使っていない / 手動で更新したい場合は以下でcrontabの書き換えができます:

``` sh
$ bundle exec whenever --update-crontab
```

手動でのTwitterプロフィール画像の取得・成果報告の更新は、それぞれ以下のコマンドを用いると行えます:

``` sh
$ bundle exec rake users:fetch_profile_image RAILS_ENV=production
$ bundle exec rake achievements:fetch RAILS_ENV=production
```
